### PR TITLE
msm8960: define HFP_ASM_RX_TX 24

### DIFF
--- a/hal/msm8960/platform.h
+++ b/hal/msm8960/platform.h
@@ -125,6 +125,8 @@ enum {
 #define LOW_LATENCY_CAPTURE_PERIOD_SIZE 240
 #define LOW_LATENCY_CAPTURE_USE_CASE 0
 
+#define HFP_ASM_RX_TX 24
+
 #define PLATFORM_INFO_XML_PATH          "/system/etc/audio_platform_info.xml"
 #define PLATFORM_INFO_XML_BASE_STRING   "/system/etc/audio_platform_info"
 


### PR DESCRIPTION
Taken from hardware/qcom/audio-car/msm8960/hal/msm8969/platform.h
Fixes build error from android-7.1.2_r2 merge:
hardware/qcom/audio/default/hal/audio_extn/utils.c:150:25:
error: use of undeclared identifier 'HFP_ASM_RX_TX'
        pcm_device_id = HFP_ASM_RX_TX;

Change-Id: I6434c31b0310be87fa7c2128da5d641898787c4f